### PR TITLE
Remove Jekyll Jupyter notebook plugin from build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ group :jekyll_plugins do
     gem 'jekyll-feed'
     gem 'jekyll-get-json'
     gem 'jekyll-imagemagick'
-    gem 'jekyll-jupyter-notebook'
     gem 'jekyll-link-attributes'
     gem 'jekyll-minifier'
     gem 'jekyll-paginate-v2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,8 +147,6 @@ GEM
       jekyll (>= 3.0)
     jekyll-imagemagick (1.4.0)
       jekyll (>= 3.4)
-    jekyll-jupyter-notebook (0.0.6)
-      jekyll
     jekyll-link-attributes (1.0.1)
     jekyll-minifier (0.1.10)
       cssminify2 (~> 2.0)
@@ -297,7 +295,6 @@ DEPENDENCIES
   jekyll-feed
   jekyll-get-json
   jekyll-imagemagick
-  jekyll-jupyter-notebook
   jekyll-link-attributes
   jekyll-minifier
   jekyll-paginate-v2

--- a/_config.yml
+++ b/_config.yml
@@ -202,7 +202,6 @@ plugins:
   - jekyll-feed
   - jekyll-get-json
   - jekyll-imagemagick
-  - jekyll-jupyter-notebook
   - jekyll-link-attributes
   - jekyll-minifier
   - jekyll-paginate-v2


### PR DESCRIPTION
## Summary
- remove the jekyll-jupyter-notebook plugin from the Gemfile and site configuration so the build no longer tries to execute notebooks

## Testing
- bundle exec jekyll build *(fails: `bundler: command not found: jekyll` because `bundle install` cannot download gems in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d432dd4c088323aa2033bf357a78cc